### PR TITLE
smath.nim: replaced fmod calls with mod (fmod deprecated 6/19)

### DIFF
--- a/src/seqmath/smath.nim
+++ b/src/seqmath/smath.nim
@@ -409,7 +409,7 @@ proc eMod*[T](x, y: openArray[T]): seq[float] =
   result = newSeq[float](x.len)
   for i in 0..<x.len:
     if y[i] == 0: result[i] = 0.0
-    else: result[i] = fmod(x[i].toFloat, y[i].toFloat)
+    else: result[i] = (x[i].toFloat mod y[i].toFloat)
 
 proc eMod*[T](x: openArray[T], y: T): seq[float] =
   ## ``modulus`` or ``remainder`` of ``x`` and ``y`` as a sequence,
@@ -422,7 +422,7 @@ proc eMod*[T](x: openArray[T], y: T): seq[float] =
   result = newSeq[float](x.len)
   for i in 0..<x.len:
     if y == 0: result[i] = 0.0
-    else: result[i] = fmod(x[i].toFloat, y.toFloat)
+    else: result[i] = (x[i].toFloat mod y.toFloat)
 
 proc eRem*[T](x, y: openArray[T]): seq[float] =
   ## ``remainder`` - use eMod
@@ -852,7 +852,7 @@ proc unwrap*[T](p: openArray[T], discont = PI): seq[float] =
     if d != prevd:
       if d < PI and d > discont: continue
       # normalise back to range of -PI to PI
-      let m = fmod(p[i], PI2)
+      let m = (p[i] mod PI2)
       if m > PI:
         result[i] = m - PI2
       else:


### PR DESCRIPTION
fmod proc was deprecated from math module in August 2019: https://nim-lang.org/0.20.0/math.html#fmod%2Cfloat32%2Cfloat32

- replaced three calls to fmod in smath.nim with the corresponding mod operation